### PR TITLE
Reworded "Scaling" paragraph in "Why?"

### DIFF
--- a/why.md
+++ b/why.md
@@ -43,9 +43,9 @@ mean that the others are compromised, too.
 ### (Independent) Scaling
 
 Each SCS can run on one or multiple servers to deal with high
-load. The SCS contains also the database and does not talk to other
-SCS. So just scaling a single SCS is enough to support a larger number
-of requests of a certain type.
+load. Each SCS also manages its own data persistency, and does not share
+a central data persistence system with other SCSs. Thus, increased local
+demand can be managed by scaling locally.
 
 ### Replaceability
 


### PR DESCRIPTION
Motivation:
Not every SCS necessarily uses a database - after all the
choice of technology is local to each SCS. Therefore, the more general
term "data persistency" is used.
"Does not talk to other SCS" is misleading, because using interfaces,
SCSs do talk with each other. I think this part of the architecture is
more about not sharing one central database because that hinders
scaling.
