### PR TITLE
fix links rendering in firefox

### DIFF
--- a/css/scs.css
+++ b/css/scs.css
@@ -340,9 +340,9 @@ label > .label-body {
 /* Lists
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 ul {
-  list-style: circle inside; }
+  list-style: circle outside; }
 ol {
-  list-style: decimal inside; }
+  list-style: decimal outside; }
 ol, ul {
   padding-left: 0;
   margin-top: 0; }
@@ -353,7 +353,8 @@ ol ul {
   margin: 1.5rem 0 1.5rem 3rem;
   font-size: 90%; }
 li {
-  margin-bottom: 2rem; }
+  margin-bottom: 2rem;
+  margin-left: 2rem;}
 
 @media (min-width: 750px) {
   ol li {


### PR DESCRIPTION
- This PR fixes links rendering in firefox (see screenshot)
- Furthermore it renders lists a nicer way with indented items (e.g. http://scs-architecture.org/vs-ms.html)

![screen shot 2015-12-09 at 10 01 13](https://cloud.githubusercontent.com/assets/1260530/11680921/e4cce208-9e5b-11e5-94ea-9a6243ab6fee.png)
