### PR TITLE
Fixes / optimizes links

### DIFF
--- a/links.md
+++ b/links.md
@@ -7,9 +7,9 @@ description: Links to further information about SCS (Self-contained Systems)
 Links
 ---
 
-* [English Infodeck](https://speakerdeck.com/rstrangh/self-contained-systems-1)  [Keynote](slidedeck/en/scs-infodeck-english.key) [PowerPoint](slidedeck/en/scs-infodeck-english.ppt)
+* [English Infodeck](https://speakerdeck.com/rstrangh/self-contained-systems-1)  [Keynote](slidedeck/en/scs-infodeck-english.key) [PowerPoint](slidedeck/en/scs-infodeck-english.pptx)
 
-* [German Infodeck](https://speakerdeck.com/rstrangh/self-contained-systems-german)  [Keynote](slidedeck/de/scs-infodeck-deutsch.key) [PowerPoint](slidedeck/de/scs-infodeck-deutsch.ppt)
+* [German Infodeck](https://speakerdeck.com/rstrangh/self-contained-systems-german)  [Keynote](slidedeck/de/scs-infodeck-deutsch.key) [PowerPoint](slidedeck/de/scs-infodeck-deutsch.pptx)
 
 * [Twitter](https://twitter.com/scsarchitecture)
 
@@ -21,7 +21,7 @@ Links
  by Stefan Tilkov about Modularization for Sustainable Systems -
  mentions SCS on slide 28ff
 
-* [ROCA](http://roca-style.org/) a style for web applications that
+* [ROCA](https://roca-style.org/) a style for web applications that
 fits SCS.
 
 * [Article on InfoQ](https://www.infoq.com/articles/scs-microservices-done-right)
@@ -34,38 +34,38 @@ fits SCS.
   talks about client-side web integration.
 
 * [Example](https://blog.codecentric.de/en/2015/01/self-contained-systems-roca-complete-example-using-spring-boot-thymeleaf-bootstrap/)
-  for SCS and [ROCA](http://roca-style.org) at the Codecentric Blog
+  for SCS and [ROCA](https://roca-style.org) at the Codecentric Blog
 
-* [Architekturprinzipien](http://dev.otto.de/2013/04/14/architekturprinzipien-2/)
+* [Architekturprinzipien](https://www.otto.de/jobs/technology/techblog/artikel/architekturprinzipien_2013-04-15.php)
   at Otto Blog, German
 
-* [Why Microservices](http://dev.otto.de/2016/03/20/why-microservices/)
+* [Why Microservices](https://www.otto.de/jobs/technology/techblog/artikel/why-microservices_2016-03-20.php)
  at Otto Blog, English
 
-* [Architektur der Galeria.de Plattform](http://galeria-kaufhof.github.io/general/2015/12/15/architektur-und-organisation-im-galeria-de-produktmanagement)
+* [Architektur der Galeria.de Plattform](https://tech.kaufhof.io/general/2015/12/15/architektur-und-organisation-im-galeria-de-produktmanagement)
   at GALERIA Kaufhof Technology Blog, German
 
-* [The rocky road from Monolith to Microservices](http://kuehne-nagel.github.io/monolith-to-microservices) by [Björn Kimminich](https://github.com/bkimminich) about desiccation of an enterprise scale monolith at Kuehne + Nagel - mentions SCS on [slide 28](http://kuehne-nagel.github.io/monolith-to-microservices/#/28)ff
+* [The rocky road from Monolith to Microservices](https://kuehne-nagel.github.io/monolith-to-microservices) by [Björn Kimminich](https://github.com/bkimminich) about desiccation of an enterprise scale monolith at Kuehne + Nagel - mentions SCS on [slide 28](https://kuehne-nagel.github.io/monolith-to-microservices/#/28)ff
 
-* [Blog Post "Carving the Java EE Monolith Into Microservices: Prefer Verticals Not Layers" with reference to SCS](http://blog.christianposta.com/microservices/carving-the-java-ee-monolith-into-microservices-perfer-verticals-not-layers/)
+* [Blog Post "Carving the Java EE Monolith Into Microservices: Prefer Verticals Not Layers" with reference to SCS](https://blog.christianposta.com/microservices/carving-the-java-ee-monolith-into-microservices-perfer-verticals-not-layers/)
 
-* [Article at InfoQ](http://www.infoq.com/articles/microservices-real-world)
+* [Article at InfoQ](https://www.infoq.com/articles/microservices-real-world)
 
-* [Self-Contained Systems - Microservices for Dummies](http://dejanglozic.com/2016/01/04/self-contained-systems-microservices-for-dummies/)
+* [Self-Contained Systems - Microservices for Dummies](https://dejanglozic.com/2016/01/04/self-contained-systems-microservices-for-dummies/)
   at the blog of Dejan Glozic
 
-* [Content tagged with SCS](https://www.innoq.com/en/timeline/?tag=scs) at the innoQ blog
+* [Content tagged with SCS](https://www.innoq.com/en/topics/scs/) at the innoQ blog
 
 * [Original German article (2011)](https://www.innoq.com/de/links/softwarearchitektur-im-grossen/)
 
-* [German Blog Post at heise developer / Continuous Architecture Blog](http://www.heise.de/developer/artikel/Self-contained-Systems-ein-Architekturstil-stellt-sich-vor-3038718.html)
+* [German Blog Post at heise developer / Continuous Architecture Blog](https://www.heise.de/developer/artikel/Self-contained-Systems-ein-Architekturstil-stellt-sich-vor-3038718.html)
 
 * [EnterpriseTales: Des Microservice großer Bruder](https://jaxenter.de/enterprisetales-des-microservice-grosser-bruder-39180)
 
-* [Breaking Down a Monolithic Software: A Case for Microservices vs. Self-Contained Systems](http://www.elastic.io/breaking-down-monolith-microservices-and-self-contained-systems/) at the elastic.io Blog
+* [Breaking Down a Monolithic Software: A Case for Microservices vs. Self-Contained Systems](https://www.elastic.io/breaking-down-monolith-microservices-and-self-contained-systems/) at the elastic.io Blog
 
 * [Building and Trusting a Cloud Bank - Starling Bank](https://www.infoq.com/presentations/starling-bank-resilience/) by Greg Hawkins. This talk explains some basic principles of an SCS architecture and shows its advantages with regards to resilience. Note, however, that there is no web UI, so the system at hand does not fully comply with the SCS definition.
 
-* [Self-Contained Systems in Practice with Vaadin and Feeds](https://blog.philipphauer.de/self-contained-systems-vaadin-feeds/) at Philipp Hauer's blog talks about a concrete SCS-based system.
+* [Self-Contained Systems in Practice with Vaadin and Feeds](https://phauer.com/2018/self-contained-systems-vaadin-feeds/) at Philipp Hauer's blog talks about a concrete SCS-based system.
 
 * [Content on GitHub](https://github.com/innoq/SCS)


### PR DESCRIPTION
The PR fixes / optimizes several links.

Fixed links:
- German Infodeck Powerpoint
- English Infodeck Powerpoint
- Content tagged with SCS at the innoQ blog

Changes the protocol for several links to https.

Changes URL of
- Architektur der Galeria.de Plattform
- Architekturprinzipien at Otto Blog, German
- Why Microservices at Otto Blog, English
- Self-Contained Systems in Practice with Vaadin and Feeds
because the respective requested resource has been moved to a new URL
