### PR TITLE
close link tag for canonical link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
   <link rel="icon" href="img/favicon.svg" type="image/svg+xml">
   <link rel="apple-touch-icon" sizes="180x180" href="img/apple-touch-icon.png">
   <link rel="manifest" href="site.webmanifest">
-  <link rel="canonical" href="{{page.canonical_url}}"
+  <link rel="canonical" href="{{page.canonical_url}}">
   <script defer data-domain="scs-architecture.org" src="https://plausible.io/js/script.outbound-links.js"></script>
 </head>
 


### PR DESCRIPTION
the canonical link tag is broken, most likely breaking the following script tag for most browsers as well.